### PR TITLE
fix: sync/rate fixes rate:wait() on infinite rps

### DIFF
--- a/sync.lua
+++ b/sync.lua
@@ -1,5 +1,5 @@
 local sync = {
-	_VERSION = '0.11.0',
+	_VERSION = '0.11.1',
 }
 
 sync.cond  = require 'sync.cond'

--- a/sync/rate.lua
+++ b/sync/rate.lua
@@ -123,12 +123,12 @@ end
 ---@return boolean|sync.rate.reservation reservation, any? error_or_time_to_act
 function rate:_reserve(time, n, wait)
     if self.rps == math.huge then
-        return true
+        return true, time
     end
     if self.rps == 0 then
         if self.burst >= n then
             self.burst = self.burst - n
-            return true
+            return true, time
         end
         return false, "not enough burst"
     end

--- a/test/06-limit.test.lua
+++ b/test/06-limit.test.lua
@@ -112,7 +112,7 @@ test:deadline(function()
 
 		test:ok(almost_gt(reserv.timeToAct, fiber.time()+1/rate.rps, 0.01), "timeToAct ≥ now+1/rps")
 		test:ok(almost_gt(fiber.time()+2/rate.rps, reserv.timeToAct, 0.01), "timeToAct ≤ now+2/rps")
-		reserv:cancel() -- cancell reservation
+		reserv:cancel() -- cancel reservation
 
 		reserv = rate:reserve()
 		assert(reserv)
@@ -141,6 +141,9 @@ test:deadline(function()
 	test:noyield(function()
 		for _ = 1, 5 do
 			test:ok(rate:allow(), "infinite rate almost allows")
+		end
+		for _ = 1, 5 do
+			test:ok(rate:wait(), "infinite rate never waits")
 		end
 	end)
 


### PR DESCRIPTION
	* rate:wait() crashed for rates with infinite rps _reserve must return numeric `timeToAct` if reservation is allowed